### PR TITLE
Allow to configure OpProcessor

### DIFF
--- a/main.js
+++ b/main.js
@@ -77,6 +77,7 @@ function createWindow() {
       serverPort: 8182,
       userName: "",
       password: "",
+      opProcessor: "",
       useSSL: false
     };
     settings.set("loginInfo", setting);
@@ -110,7 +111,7 @@ app.on('activate', () => {
 
 ipc.on('query:execute', (e, query) => {
   client = Gremlin.createClient(settings.get("loginInfo.serverPort"), settings.get("loginInfo.serverName"),
-    { ssl: settings.get("loginInfo.useSSL"), user: settings.get("loginInfo.userName"), password: settings.get("loginInfo.password") });
+    { ssl: settings.get("loginInfo.useSSL"), user: settings.get("loginInfo.userName"), password: settings.get("loginInfo.password"), processor: settings.get("loginInfo.opProcessor") || ""});
   if (client == null) {
     client = connectToDatabase();
   }
@@ -132,7 +133,7 @@ ipc.on('connection:newConnection', (e) => {
 
 function connectToDatabase(loginInfo) {
   console.log("connectToDatabase");
-  const db = Gremlin.createClient(loginInfo.serverPort, loginInfo.serverName, { ssl: loginInfo.useSSL, user: loginInfo.userName, password: loginInfo.password });
+  const db = Gremlin.createClient(loginInfo.serverPort, loginInfo.serverName, { ssl: loginInfo.useSSL, user: loginInfo.userName, password: loginInfo.password, processor: loginInfo.opProcessor || ""});
   return db;
 }
 

--- a/src/components/ConnectionSetup.js
+++ b/src/components/ConnectionSetup.js
@@ -33,6 +33,7 @@ class ConnectionSetup extends React.Component {
             serverPort: 8182,
             userName: "",
             password: "",
+            opProcessor: "",
             useSSL: false
         }
         this.handleClose = this.handleClose.bind(this);
@@ -43,6 +44,7 @@ class ConnectionSetup extends React.Component {
         this.handlePasswordChanges = this.handlePasswordChanges.bind(this);
         this.handleSSLChanges = this.handleSSLChanges.bind(this);
         this.testConnection = this.testConnection.bind(this);
+        this.handleOpProcessorChanges = this.handleOpProcessorChanges.bind(this);
     }
 
     componentWillMount() {
@@ -51,6 +53,7 @@ class ConnectionSetup extends React.Component {
             serverPort: settings.get("loginInfo.serverPort"),
             userName: settings.get("loginInfo.userName"),
             password: settings.get("loginInfo.password"),
+            opProcessor: settings.get("loginInfo.opProcessor"),
             useSSL: Boolean(settings.get("loginInfo.useSSL"))
         })
     }
@@ -77,6 +80,7 @@ class ConnectionSetup extends React.Component {
             serverPort: this.state.serverPort,
             userName: this.state.userName,
             password: this.state.password,
+            opProcessor: this.state.opProcessor,
             useSSL: Boolean(this.state.useSSL)
         })
         ipcRenderer.send("connection:newConnection");
@@ -105,6 +109,10 @@ class ConnectionSetup extends React.Component {
 
     handlePasswordChanges(event) {
         this.setState({ password: event.currentTarget.value })
+    }
+
+    handleOpProcessorChanges(event) {
+        this.setState({ opProcessor: event.currentTarget.value })
     }
 
     render() {
@@ -158,6 +166,15 @@ class ConnectionSetup extends React.Component {
                             fullWidth
                             value={this.state.password}
                             onChange={this.handlePasswordChanges}
+                        />
+                        <TextField
+                            margin="normal"
+                            id="opProcessor"
+                            label="Op Processor"
+                            type="text"
+                            fullWidth
+                            value={this.state.opProcessor}
+                            onChange={this.handleOpProcessorChanges}
                         />
                         <FormControlLabel
                             control={


### PR DESCRIPTION
Add an option to configure [OpProcessor](https://tinkerpop.apache.org/docs/current/reference/#opprocessor-configurations) name in Connection Setup.

This is useful, for example, to connect to [Gremlin Server Cypher Plugin](https://github.com/opencypher/cypher-for-gremlin/tree/master/tinkerpop/cypher-gremlin-server-plugin).